### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 `sveltekit-i18n` is a tiny library with no external dependencies, built for [Svelte](https://github.com/sveltejs/svelte) and [SvelteKit](https://github.com/sveltejs/kit). It glues [@sveltekit-i18n/base](https://github.com/sveltekit-i18n/base) and [@sveltekit-i18n/parser-default](https://github.com/sveltekit-i18n/parsers/tree/master/parser-default) together to provide you the most straightforward `sveltekit-i18n` solution.
 
 __Note this README is related to `sveltekit-i18n@2.x`. If you are looking for version `1.x` you can find it [here](https://github.com/sveltekit-i18n/lib/tree/1.x).__
+&nbsp;
+
+&nbsp;
 
 ## Key features
 
@@ -15,124 +18,99 @@ __Note this README is related to `sveltekit-i18n@2.x`. If you are looking for ve
 ✅ Custom modifiers – you can modify the input data the way you really need\
 ✅ TS support\
 ✅ No external dependencies
+&nbsp;
+
+&nbsp;
 
 ## Usage
 
-Setup `translations.js` in your lib folder...
-```javascript
+Setup `translations.js/ts` in your `lib` folder...
+```typescript
 import i18n from 'sveltekit-i18n';
+import type { Config } from 'sveltekit-i18n';
 
-/** @type {import('sveltekit-i18n').Config} */
-const config = ({
+const config: Config = ({
   loaders: [
     {
       locale: 'en',
-      key: 'common',
+      key: 'home',
       loader: async () => (
         await import('./en/common.json')
       ).default,
     },
     {
-      locale: 'en',
+      locale: 'cs',
       key: 'home',
-      routes: ['/'], // you can use regexes as well!
       loader: async () => (
-        await import('./en/home.json')
+        await import('./cs/common.json')
       ).default,
     },
     {
       locale: 'en',
       key: 'about',
-      routes: ['/about'],
       loader: async () => (
         await import('./en/about.json')
       ).default,
     },
     {
       locale: 'cs',
-      key: 'common',
-      loader: async () => (
-        await import('./cs/common.json')
-      ).default,
-    },
-    {
-      locale: 'cs',
-      key: 'home',
-      routes: ['/'],
-      loader: async () => (
-        await import('./cs/home.json')
-      ).default,
-    },
-    {
-      locale: 'cs',
       key: 'about',
-      routes: ['/about'],
       loader: async () => (
         await import('./cs/about.json')
       ).default,
-    },
+    }
   ],
 });
 
 export const { t, locale, locales, loading, loadTranslations } = new i18n(config);
 ```
 
-...load your translations in `__layout.svelte`...
+...load your translations in `+page.ts` or `+layout.ts`...
 
-```svelte
-<script context="module">
+```typescript
+<script lang="ts">
+  import type { PageLoad } from "./$types";
   import { locale, loadTranslations } from '$lib/translations';
 
-  export const load = async ({ url }) => {
+  export const load: PageLoad = async ({ url }) => {
     const { pathname } = url;
 
-    const defaultLocale = 'en'; // get from cookie, user session, ...
+    // Get from localStorage, cookie, etc...
+    const defaultLocale = 'en';
     
-    const initLocale = locale.get() || defaultLocale; // set default if no locale already set
+    // Set default if no locale already set
+    const initLocale = locale.get() || defaultLocale;
 
-    await loadTranslations(initLocale, pathname); // keep this just before the `return`
+    // Keep this just before the `return`
+    await loadTranslations(initLocale, pathname);
 
     return {};
   }
 </script>
 ```
 
-<details><summary>+layout.ts example</summary>
+...include your translations within pages and components...
 
-  In modern SvelteKit `+layout.ts` is used instead of `__layout.svelte`.
-
-  ```ts
-  import { loadTranslations, locale } from '$lib/translations/translations';
-  import type { LayoutLoad } from './$types';
-
-  export const load: LayoutLoad = async ({ url }) => {
-    const { pathname } = url;
-    const defaultLocale = 'en'; // get from cookie, user session, ...
-    const initLocale = locale.get() || defaultLocale; // set default if no locale already set
-    await loadTranslations(initLocale, pathname); // keep this just before the `return`
-
-    return {};
-  }
-```
-</details>
-
-...and include your translations within pages and components.
-
-```svelte
+```typescript
 <script>
   import { t } from '$lib/translations';
 
   const pageName = 'This page is Home page!';
 </script>
-
+```
+```svelte
 <div>
   <!-- you can use `placeholders` and `modifiers` in your definitions (see docs) -->
-  <h2>{$t('common.page', { pageName })}</h2>
-  <p>{$t('home.content')}</p>
+  <h2>{$t('home.page', { pageName })}</h2>
+  <p>{$t('about.title')}</p>
 </div>
 ```
+...and switch `$locale` between preferred languages `"en"` > `"cs"` to see the results.
+&nbsp;
+
+&nbsp;
 
 ## More info
 [Docs](https://github.com/sveltekit-i18n/lib/tree/master/docs/README.md)\
-[Examples](https://github.com/sveltekit-i18n/lib/tree/master/examples)\
+[Examples](https://github.com/sveltekit-i18n/lib/tree/master/examples) (made before latest routing/load updates)\
 [Changelog](https://github.com/sveltekit-i18n/lib/releases)


### PR DESCRIPTION
1. Remade for ts
2. Sorted loaders objects in example, for least confusion possible
3. +layout.ts changed for "+page.ts or +layout.ts", because updated docs present +page.ts as the first data loading place, so it seems straighter
4. svelte code tag changed for typescript+svelte, because svelte doesn't syntax highlight js
5. Added "...and switch $locale between preferred languages "en" > "cs" to see results."
6. Bigger spaces between paragraphs by using trick with nbsp; I found on stackoverflow, looks clearer
7. Added "(made before latest routing/load updates)" after "Examples" link

I think that's how it should look, but this is just my opinion