### PR TITLE
Fixed language detection for no regional variant

### DIFF
--- a/examples/multi-page/src/routes/+layout.server.js
+++ b/examples/multi-page/src/routes/+layout.server.js
@@ -7,10 +7,20 @@ export const load = async ({ url, cookies, request }) => {
   // Try to get the locale from cookie
   let locale = (cookies.get('lang') || '').toLowerCase();
 
-  // Get user preferred locale
-  if (!locale) {
-    locale = `${`${request.headers.get('accept-language')}`.match(/[a-zA-Z]+?(?=-|_|,|;)/)}`.toLowerCase();
-  }
+	// Get user preferred locale
+	if (!locale) {
+		const acceptLanguageHeader = request.headers.get('accept-language');
+		let match = acceptLanguageHeader.match(/^[a-zA-Z]+(?=[-_])/);
+
+		// If no match, try to get the locale without the region
+		if (!match) {
+			match = acceptLanguageHeader.match(/^[a-zA-Z]+/);
+		}
+
+		if (match) {
+			locale = match[0].toLowerCase();
+		}
+	}
 
   // Get defined locales
   const supportedLocales = locales.get().map((l) => l.toLowerCase());


### PR DESCRIPTION
This commit refines the approach to extracting language codes from the `Accept-Language` header. 

By employing a unified regex pattern, the code now efficiently captures both simple language codes and those with regional variants. 

The language code extraction logic now also splits on both hyphens and underscores, defaulting to the primary language code in cases of regional variants, and always converts the result to lowercase for consistent processing.